### PR TITLE
remove locks on sender-side of mpsc channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.16] Q1 2023
+ - fixed redundant locking on twin
+ - fixed redundant locking on iot messages
+
 ## [0.4.15] Q1 2023
  - simplified twin singleton
  - prepared readme for open sourcing repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "iot-client-template-rs"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "azure-iot-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iot-client-template-rs"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 authors = ["omnect@conplement.de>"]
 repository = "git@github.com:omnect/iot-client-template-rs.git"

--- a/src/direct_methods.rs
+++ b/src/direct_methods.rs
@@ -3,10 +3,11 @@ use anyhow::Result;
 use azure_iot_sdk::client::*;
 use serde_json::json;
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex};
 
-pub fn get_direct_methods(tx_app2client: Arc<Mutex<Sender<Message>>>) -> Option<DirectMethodMap> {
+pub fn get_direct_methods(tx_app2client: &Sender<Message>) -> Option<DirectMethodMap> {
     let mut methods = DirectMethodMap::new();
+
+    let tx_app2client = tx_app2client.clone();
 
     methods.insert(
         String::from("closure_send_d2c_message"),
@@ -23,8 +24,6 @@ pub fn get_direct_methods(tx_app2client: Arc<Mutex<Sender<Message>>>) -> Option<
                 .unwrap();
 
             tx_app2client
-                .lock()
-                .unwrap()
                 .send(Message::D2C(msg))
                 .unwrap();
             Ok(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use client::{Client, Message};
 use log::{debug, error};
 use std::matches;
 use std::sync::Once;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::mpsc;
 use twin::ReportProperty;
 
 static INIT: Once = Once::new();
@@ -20,9 +20,9 @@ pub async fn run() -> Result<()> {
     let mut client = Client::new();
     let (tx_client2app, rx_client2app) = mpsc::channel();
     let (tx_app2client, rx_app2client) = mpsc::channel();
-    let tx_app2client = Arc::new(Mutex::new(tx_app2client));
-    let methods = direct_methods::get_direct_methods(Arc::clone(&tx_app2client));
-    let twin = twin::get_or_init(Some(Arc::clone(&tx_app2client)));
+
+    let methods = direct_methods::get_direct_methods(&tx_app2client);
+    let twin = twin::get_or_init(Some(&tx_app2client));
 
     client.run(None, methods, tx_client2app, rx_app2client);
 
@@ -47,7 +47,7 @@ pub async fn run() -> Result<()> {
                     .unwrap_or_else(|e| error!("update: {:#?}", e));
             }
             Message::C2D(msg) => {
-                message::update(msg, Arc::clone(&tx_app2client));
+                message::update(msg, &tx_app2client);
             }
             _ => debug!("Application received unhandled message"),
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,9 +2,8 @@ use crate::Message;
 use azure_iot_sdk::client::IotMessage;
 use log::debug;
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex};
 
-pub fn update(msg: IotMessage, _tx_app2client: Arc<Mutex<Sender<Message>>>) {
+pub fn update(msg: IotMessage, _tx_app2client: &Sender<Message>) {
     debug!(
         "Received C2D message with \n body: {:?}\n properties: {:?} \n system properties: {:?}",
         std::str::from_utf8(&msg.body).unwrap(),


### PR DESCRIPTION
Remove the locks on the shared app2client Sender. Senders implement the Send Trait. This allows them to be shared by copying and moving them to other threads (for example, see the "Shared Usage" example in
https://doc.rust-lang.org/std/sync/mpsc).

This simplifies the function calls and the unpacking logic. Furthermore, this reduces overall locking, as the Sender internally takes care of synchronization.

Note: this is currently untested